### PR TITLE
feat/add n score

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The maximum agreement is the number of projects (implicitly annotators) being co
 
 You will have access to 2 sliders, which allow you to filter by two parameters:
 1. Minimum Agreement
-2. Score
+2. Integrated Agreement Score
 
 When you apply these filters, you will see regions of interest, which are automatically identified by the tool.
 
@@ -98,7 +98,7 @@ It is important to note that this does not mean that you will only see the regio
 You will see the entire region of interest, but there will have to be a place where at least N annotators agreed at any one point.
 This agreement does not have to span the whole region of interest.
 
-#### Score
+#### Integrated Agreement Score
 For a given region of interest, there will be a certain number of 'points' available.
 This number of available points is the number of frames that the region of interest spans multiplied by the total possible number of annotators (i.e. the numnber of projects being compared).
 The number of points achieved is the sum of all the frames which each annotator who labelled this region of interest submitted.
@@ -106,11 +106,32 @@ The number of points achieved is the sum of all the frames which each annotator 
 The score is `number_of_points_achieved / number_of_points_available`
 
 For example, if consensus is being run on 4 projects and there is a region of interest spanning 10 frames, the maximum number of points available is `4 x 10 = 40`.
-If 1 annotator labelled frames 1-10, this counts as 10 points achieved. The score would be `10 / 40 = 0.25` for this region.
-If another annotator labelled frames 1-5, then this would add another 5 points. The total score would be `(10 + 5) / 40 = 0.375` for this region.
+If 1 annotator labelled frames 1-10, this counts as 10 points achieved. The integrated agreement score would be `10 / 40 = 0.25` for this region.
+If another annotator labelled frames 1-5, then this would add another 5 points. The total integrated agreement score would be `(10 + 5) / 40 = 0.375` for this region.
 
-If all 4 annotators had labelled 1-10 in this region, then the score would be `(10 x 4) / 40 = 1`, which is the maximum possible score.
-This makes sense as a score of 1 implies perfect agreement.
+If all 4 annotators had labelled 1-10 in this region, then the integrated agreement score would be `(10 x 4) / 40 = 1`, which is the maximum possible score.
+This makes sense as a integrated agreement score of 1 implies perfect agreement.
+
+
+#### N Score
+For a given region of interest, where N annotators have contributed to the region, there will be a total of N-1 values of N score, ranging from the 2-score up to the N-1 score in increments of 1.
+For example, for a region where 3 annotators have contributed will have a 2-score and a 3-score.
+The N-score is defined thus:
+```
+number of frames with at least N annotators voting / number of frames with more than 1 annotator voting
+```
+The denominator is equivalent to the span of the region of interest, since regions need at least 1 annotator voting for this classification.
+
+An example calculation is shown below for a given region of interest:
+```commandline
+At least 1 annotators agreeing: 57 frames
+At least 2 annotators agreeing: 52 frames
+At least 3 annotators agreeing: 20 frames
+
+N Scores
+2-score: 52/57=0.9123
+3-score: 20/57=0.3509
+```
 
 ## Export
 ### Usage
@@ -132,7 +153,10 @@ At the frame label level:
 
 At the label blurb level:
 - `classification_answers` has not changed, except for the fact that `regionHash` is used instead of `objectHash`.
-- `consensus_meta` has been added. This is keyed on the `regionHash` and includes the `score` of the region along with the fully qualified answer string `answer_fq_name`.
+- `consensus_meta` has been added. This is keyed on the `regionHash` and includes:
+  - `integrated_agreement_score` of the region
+  - fully qualified answer string `answer_fq_name`
+  - `n_scores` which is a json blob containing each n score, the keys are string `N` and the value is the float score.
 
 
 ## CLI

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -214,18 +214,22 @@ if st.session_state.lr_data:
     for region in st.session_state.regions_of_interest:
         if (
             region.max_agreement >= st.session_state.min_agreement_slider
-            and region.score >= st.session_state.min_score_slider
+            and region.score_data.integrated_agreement_score
+            >= st.session_state.min_score_slider
         ):
             st.checkbox(
                 "Select", on_change=st_select_region, args=(region,), key=hash(region)
             )
-            mini_report = f"Mini Report\nScore: {round(region.score, 2)}\n" + "\n".join(
-                [
-                    f"At least {k} annotators agreeing: {v} frames"
-                    for k, v in calculate_region_frame_level_integrated_agreement(
-                        region
-                    ).items()
-                ]
+            mini_report = (
+                f"Mini Report\nScore: {round(region.score_data.integrated_agreement_score, 2)}\n"
+                + "\n".join(
+                    [
+                        f"At least {k} annotators agreeing: {v} frames"
+                        for k, v in calculate_region_frame_level_integrated_agreement(
+                            region
+                        ).items()
+                    ]
+                )
             )
             identifier_text = (
                 f"Region number {region.region_number}\n\nSelected Answers\n"

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -213,7 +213,7 @@ if st.session_state.lr_data:
     )
     for region in st.session_state.regions_of_interest:
         if (
-            region.max_agreement >= st.session_state.min_agreement_slider
+            region.consensus_data.max_agreement >= st.session_state.min_agreement_slider
             and region.consensus_data.integrated_agreement_score
             >= st.session_state.min_score_slider
         ):

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -214,14 +214,14 @@ if st.session_state.lr_data:
     for region in st.session_state.regions_of_interest:
         if (
             region.max_agreement >= st.session_state.min_agreement_slider
-            and region.score_data.integrated_agreement_score
+            and region.consensus_data.integrated_agreement_score
             >= st.session_state.min_score_slider
         ):
             st.checkbox(
                 "Select", on_change=st_select_region, args=(region,), key=hash(region)
             )
             mini_report = (
-                f"Mini Report\nScore: {round(region.score_data.integrated_agreement_score, 2)}\n"
+                f"Mini Report\nScore: {round(region.consensus_data.integrated_agreement_score, 2)}\n"
                 + "\n".join(
                     [
                         f"At least {k} annotators agreeing: {v} frames"

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -13,6 +13,7 @@ from lib.frame_label_consensus import (
     find_regions_of_interest,
     calculate_region_frame_level_min_n_agreement,
     aggregate_by_answer,
+    calculate_n_scores,
 )
 from lib.project_access import (
     get_user_client,
@@ -221,13 +222,18 @@ if st.session_state.lr_data:
                 "Select", on_change=st_select_region, args=(region,), key=hash(region)
             )
             mini_report = (
-                f"Mini Report\nScore: {round(region.consensus_data.integrated_agreement_score, 2)}\n"
+                f"Mini Report\nIntegrated Agreement Score: {round(region.consensus_data.integrated_agreement_score, 2)}\n"
                 + "\n".join(
                     [
                         f"At least {k} annotators agreeing: {v} frames"
-                        for k, v in calculate_region_frame_level_min_n_agreement(
-                            region
-                        ).items()
+                        for k, v in region.consensus_data.min_n_agreement.items()
+                    ]
+                )
+                + "\n\nN Scores\n"
+                + "\n".join(
+                    [
+                        f"{n}_score: {s}"
+                        for n, s in region.consensus_data.n_scores.items()
                     ]
                 )
             )

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -230,7 +230,7 @@ if st.session_state.lr_data:
                 + "\n\nN Scores\n"
                 + "\n".join(
                     [
-                        f"{n}_score: {s}"
+                        f"{n}-score: {s}"
                         for n, s in region.consensus_data.n_scores.items()
                     ]
                 )

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -9,9 +9,9 @@ from lib.data_export import export_regions_of_interest
 from lib.data_model import RegionOfInterest
 from lib.data_transformation import prepare_data_for_consensus
 from lib.frame_label_consensus import (
-    calculate_frame_level_integrated_agreement,
+    calculate_frame_level_min_n_agreement,
     find_regions_of_interest,
-    calculate_region_frame_level_integrated_agreement,
+    calculate_region_frame_level_min_n_agreement,
     aggregate_by_answer,
 )
 from lib.project_access import (
@@ -182,7 +182,7 @@ if st.session_state.lr_data:
             )
             aggregated_data = aggregate_by_answer(prepared_data)
             st.session_state.fl_integrated_agreement = (
-                calculate_frame_level_integrated_agreement(aggregated_data)
+                calculate_frame_level_min_n_agreement(aggregated_data)
             )
             st.session_state.regions_of_interest = find_regions_of_interest(
                 aggregated_data, total_num_annnotators
@@ -225,7 +225,7 @@ if st.session_state.lr_data:
                 + "\n".join(
                     [
                         f"At least {k} annotators agreeing: {v} frames"
-                        for k, v in calculate_region_frame_level_integrated_agreement(
+                        for k, v in calculate_region_frame_level_min_n_agreement(
                             region
                         ).items()
                     ]

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -11,9 +11,7 @@ from lib.data_transformation import prepare_data_for_consensus
 from lib.frame_label_consensus import (
     calculate_frame_level_min_n_agreement,
     find_regions_of_interest,
-    calculate_region_frame_level_min_n_agreement,
     aggregate_by_answer,
-    calculate_n_scores,
 )
 from lib.project_access import (
     get_user_client,
@@ -222,7 +220,7 @@ if st.session_state.lr_data:
                 "Select", on_change=st_select_region, args=(region,), key=hash(region)
             )
             mini_report = (
-                f"Mini Report\nIntegrated Agreement Score: {round(region.consensus_data.integrated_agreement_score, 2)}\n"
+                f"Mini Report\nIntegrated Agreement Score: {region.consensus_data.integrated_agreement_score}\n\n"
                 + "\n".join(
                     [
                         f"At least {k} annotators agreeing: {v} frames"

--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -203,18 +203,18 @@ if st.session_state.lr_data:
         key="min_agreement_slider",
     )
     st.slider(
-        "Minimum Score",
+        "Minimum Integrated Agreement Score",
         min_value=0.0,
         max_value=1.0,
         value=0.0,
         step=0.05,
-        key="min_score_slider",
+        key="min_integrated_score_slider",
     )
     for region in st.session_state.regions_of_interest:
         if (
             region.consensus_data.max_agreement >= st.session_state.min_agreement_slider
             and region.consensus_data.integrated_agreement_score
-            >= st.session_state.min_score_slider
+            >= st.session_state.min_integrated_score_slider
         ):
             st.checkbox(
                 "Select", on_change=st_select_region, args=(region,), key=hash(region)

--- a/encord_consensus/lib/data_export.py
+++ b/encord_consensus/lib/data_export.py
@@ -39,8 +39,10 @@ def export_regions_of_interest(
             "classifications": region.answer.classification_answers["classifications"],
         }
         export_dict["consensus_meta"][region_hash] = {
-            "integrated_agreement_score": region.consensus_data.integrated_agreement_score,
+            "max_agreement": region.consensus_data.max_agreement,
             "answer_fq_name": region.answer.fq_name,
+            "integrated_agreement_score": region.consensus_data.integrated_agreement_score,
+            "n_scores": region.consensus_data.n_scores,
         }
 
         for frame, votes in region.frame_votes.items():

--- a/encord_consensus/lib/data_export.py
+++ b/encord_consensus/lib/data_export.py
@@ -40,7 +40,7 @@ def export_regions_of_interest(
         }
         export_dict["consensus_meta"][region_hash] = {
             "integrated_agreement_score": round(
-                region.score_data.integrated_agreement_score, 4
+                region.consensus_data.integrated_agreement_score, 4
             ),
             "answer_fq_name": region.answer.fq_name,
         }

--- a/encord_consensus/lib/data_export.py
+++ b/encord_consensus/lib/data_export.py
@@ -39,9 +39,7 @@ def export_regions_of_interest(
             "classifications": region.answer.classification_answers["classifications"],
         }
         export_dict["consensus_meta"][region_hash] = {
-            "integrated_agreement_score": round(
-                region.consensus_data.integrated_agreement_score, 4
-            ),
+            "integrated_agreement_score": region.consensus_data.integrated_agreement_score,
             "answer_fq_name": region.answer.fq_name,
         }
 

--- a/encord_consensus/lib/data_export.py
+++ b/encord_consensus/lib/data_export.py
@@ -39,7 +39,9 @@ def export_regions_of_interest(
             "classifications": region.answer.classification_answers["classifications"],
         }
         export_dict["consensus_meta"][region_hash] = {
-            "score": round(region.score, 4),
+            "integrated_agreement_score": round(
+                region.score_data.integrated_agreement_score, 4
+            ),
             "answer_fq_name": region.answer.fq_name,
         }
 

--- a/encord_consensus/lib/data_model.py
+++ b/encord_consensus/lib/data_model.py
@@ -41,6 +41,7 @@ class AggregatedView(BaseModel):
 
 
 class ConsensusData(BaseModel):
+    max_agreement: int
     integrated_agreement_score: float | None = None
     n_scores: Dict[int, float] | None = None
 
@@ -49,7 +50,6 @@ class RegionOfInterest(BaseModel):
     answer: Answer
     frame_votes: Dict[int, List[str]] = Field(allow_mutation=False)
     frame_vote_counts: Dict[int, int] = Field(allow_mutation=False)
-    max_agreement: int
     region_number: int
     consensus_data: ConsensusData | None = None
 

--- a/encord_consensus/lib/data_model.py
+++ b/encord_consensus/lib/data_model.py
@@ -42,7 +42,8 @@ class AggregatedView(BaseModel):
 
 class ConsensusData(BaseModel):
     max_agreement: int
-    integrated_agreement_score: float | None = None
+    integrated_agreement_score: float
+    min_n_agreement: Dict[int, int]
     n_scores: Dict[int, float] | None = None
 
 

--- a/encord_consensus/lib/data_model.py
+++ b/encord_consensus/lib/data_model.py
@@ -40,13 +40,18 @@ class AggregatedView(BaseModel):
     frame_votes: DefaultDict[int, List[str]] = defaultdict(list)
 
 
+class ScoreData(BaseModel):
+    integrated_agreement_score: float | None = None
+    n_scores: Dict[int, float] | None = None
+
+
 class RegionOfInterest(BaseModel):
     answer: Answer
     frame_votes: Dict[int, List[str]] = Field(allow_mutation=False)
     frame_vote_counts: Dict[int, int] = Field(allow_mutation=False)
     max_agreement: int
     region_number: int
-    score: float | None = None
+    score_data: ScoreData | None = None
 
     def __hash__(self) -> int:
         return hash(hash(self.answer) + self.region_number)

--- a/encord_consensus/lib/data_model.py
+++ b/encord_consensus/lib/data_model.py
@@ -40,7 +40,7 @@ class AggregatedView(BaseModel):
     frame_votes: DefaultDict[int, List[str]] = defaultdict(list)
 
 
-class ScoreData(BaseModel):
+class ConsensusData(BaseModel):
     integrated_agreement_score: float | None = None
     n_scores: Dict[int, float] | None = None
 
@@ -51,7 +51,7 @@ class RegionOfInterest(BaseModel):
     frame_vote_counts: Dict[int, int] = Field(allow_mutation=False)
     max_agreement: int
     region_number: int
-    score_data: ScoreData | None = None
+    consensus_data: ConsensusData | None = None
 
     def __hash__(self) -> int:
         return hash(hash(self.answer) + self.region_number)

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -92,7 +92,7 @@ def process_vote_counts(number_of_annotators_agreeing) -> Dict[int, int]:
     }
 
 
-def calculate_frame_level_integrated_agreement(
+def calculate_frame_level_min_n_agreement(
     aggregated_data: List[AggregatedView],
 ) -> Dict[int, int]:
     number_of_annotators_agreeing = []
@@ -103,7 +103,7 @@ def calculate_frame_level_integrated_agreement(
     return process_vote_counts(number_of_annotators_agreeing)
 
 
-def calculate_region_frame_level_integrated_agreement(
+def calculate_region_frame_level_min_n_agreement(
     region: RegionOfInterest,
 ) -> Dict[int, int]:
     return process_vote_counts(list(region.frame_vote_counts.values()))

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -62,6 +62,7 @@ def find_regions_of_interest(
                 integrated_agreement_score=calculate_integrated_agreement_score(
                     region, total_num_annotators
                 ),
+                min_n_agreement=calculate_region_frame_level_min_n_agreement(region),
             )
             regions.append(region)
     return regions

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -6,7 +6,7 @@ from .data_model import (
     AggregatedView,
     ClassificationView,
     RegionOfInterest,
-    ScoreData,
+    ConsensusData,
 )
 
 
@@ -58,7 +58,7 @@ def find_regions_of_interest(
                 max_agreement=max(frame_vote_counts.values()),
                 region_number=idx,
             )
-            region.score_data = ScoreData(
+            region.consensus_data = ConsensusData(
                 integrated_agreement_score=calculate_integrated_agreement_score(
                     region, total_num_annotators
                 )

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -1,7 +1,13 @@
 from collections import defaultdict
 from typing import List, DefaultDict, Dict
 
-from .data_model import Answer, AggregatedView, ClassificationView, RegionOfInterest
+from .data_model import (
+    Answer,
+    AggregatedView,
+    ClassificationView,
+    RegionOfInterest,
+    ScoreData,
+)
 
 
 def aggregate_by_answer(
@@ -52,12 +58,16 @@ def find_regions_of_interest(
                 max_agreement=max(frame_vote_counts.values()),
                 region_number=idx,
             )
-            region.score = calculate_agreement_in_region(region, total_num_annotators)
+            region.score_data = ScoreData(
+                integrated_agreement_score=calculate_integrated_agreement_score(
+                    region, total_num_annotators
+                )
+            )
             regions.append(region)
     return regions
 
 
-def calculate_agreement_in_region(
+def calculate_integrated_agreement_score(
     region: RegionOfInterest, total_num_annotators: int
 ) -> float:
     frame_vote_counts = region.frame_vote_counts

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -74,7 +74,9 @@ def calculate_integrated_agreement_score(
 ) -> float:
     frame_vote_counts = region.frame_vote_counts
     num_frames = 1 + max(frame_vote_counts.keys()) - min(frame_vote_counts.keys())
-    return sum(frame_vote_counts.values()) / (total_num_annotators * num_frames)
+    return round(
+        sum(frame_vote_counts.values()) / (total_num_annotators * num_frames), 4
+    )
 
 
 def process_vote_counts(number_of_annotators_agreeing) -> Dict[int, int]:
@@ -116,5 +118,7 @@ def calculate_n_scores(region: RegionOfInterest) -> Dict[int, float]:
     n_scores = {}
     total_num_annotators = max(frame_level_min_n_agreement.keys())
     for n in range(2, total_num_annotators + 1):
-        n_scores[n] = frame_level_min_n_agreement[n] / frame_level_min_n_agreement[1]
+        n_scores[n] = round(
+            frame_level_min_n_agreement[n] / frame_level_min_n_agreement[1], 4
+        )
     return n_scores

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -55,13 +55,13 @@ def find_regions_of_interest(
                 answer=agg_view.answer,
                 frame_votes=s,
                 frame_vote_counts=frame_vote_counts,
-                max_agreement=max(frame_vote_counts.values()),
                 region_number=idx,
             )
             region.consensus_data = ConsensusData(
+                max_agreement=max(frame_vote_counts.values()),
                 integrated_agreement_score=calculate_integrated_agreement_score(
                     region, total_num_annotators
-                )
+                ),
             )
             regions.append(region)
     return regions

--- a/encord_consensus/lib/frame_label_consensus.py
+++ b/encord_consensus/lib/frame_label_consensus.py
@@ -63,6 +63,7 @@ def find_regions_of_interest(
                     region, total_num_annotators
                 ),
                 min_n_agreement=calculate_region_frame_level_min_n_agreement(region),
+                n_scores=calculate_n_scores(region),
             )
             regions.append(region)
     return regions
@@ -108,3 +109,12 @@ def calculate_region_frame_level_min_n_agreement(
     region: RegionOfInterest,
 ) -> Dict[int, int]:
     return process_vote_counts(list(region.frame_vote_counts.values()))
+
+
+def calculate_n_scores(region: RegionOfInterest) -> Dict[int, float]:
+    frame_level_min_n_agreement = calculate_region_frame_level_min_n_agreement(region)
+    n_scores = {}
+    total_num_annotators = max(frame_level_min_n_agreement.keys())
+    for n in range(2, total_num_annotators + 1):
+        n_scores[n] = frame_level_min_n_agreement[n] / frame_level_min_n_agreement[1]
+    return n_scores

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name='encord-consensus',
-    version='0.0.13',
+    version='0.0.14',
     author='Encord',
     author_email='support@encord.com',
     description='Tool for consensus on Encord.',


### PR DESCRIPTION
Add a new scoring methodology 'n-score' which, for a given region of interest, will generate N-1 scores (where N is the number of annotators that contributed to this region).
The n score is `number of frames where at least n annotators agreed / total number of frames in region`.
The 'old' score has been renamed 'Integrated Agreement Score'.

Some additional data model changes have also been made.