### PR TITLE
fix: only allow selection of videos for consensus

### DIFF
--- a/encord_consensus/app.py
+++ b/encord_consensus/app.py
@@ -4,6 +4,7 @@ import os
 
 import streamlit as st
 from dotenv import load_dotenv
+from encord.constants.enums import DataType
 from lib.data_export import export_regions_of_interest
 from lib.data_model import RegionOfInterest
 from lib.data_transformation import prepare_data_for_consensus
@@ -22,6 +23,8 @@ from lib.project_access import (
     list_all_data_rows,
     list_projects,
 )
+
+SUPPORTED_DATA_FORMATS = [DataType.VIDEO]
 
 load_dotenv(encoding="utf-8")
 app_user_client = get_user_client(os.getenv("ENCORD_KEYFILE"))
@@ -150,7 +153,9 @@ def st_select_data_hash(data_hash, data_title):
 
 
 if not st.session_state.selected_data_hash:
-    for dr in list_all_data_rows(app_user_client, st.session_state.attached_datasets):
+    for dr in list_all_data_rows(
+        app_user_client, st.session_state.attached_datasets, data_types=SUPPORTED_DATA_FORMATS
+    ):
         emp = st.empty()
         col1, col2 = emp.columns([9, 3])
         col1.markdown(dr.title, unsafe_allow_html=True)

--- a/encord_consensus/lib/project_access.py
+++ b/encord_consensus/lib/project_access.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Optional, Set, Union
 
 from encord import EncordUserClient, Project
+from encord.constants.enums import DataType
 
 
 def get_user_client(path_to_keyfile: str) -> EncordUserClient:
@@ -33,10 +34,14 @@ def count_label_rows(user_client: EncordUserClient, project_hash: str) -> int:
     return len(label_hashes)
 
 
-def list_all_data_rows(user_client: EncordUserClient, dataset_hashes: Union[Set[str], List[str]]) -> List:
+def list_all_data_rows(
+    user_client: EncordUserClient,
+    dataset_hashes: Union[Set[str], List[str]],
+    data_types: Optional[List[DataType]] = None,
+) -> List:
     res = []
     for dataset_hash in dataset_hashes:
-        res.extend(user_client.get_dataset(dataset_hash).list_data_rows())
+        res.extend(user_client.get_dataset(dataset_hash).list_data_rows(data_types=data_types))
     return res
 
 


### PR DESCRIPTION
We are narrowing down the scope of consensus to videos, so those data formats that aren't supported will not appear in the selection for consensus in the UI.